### PR TITLE
chore: frontend environment variables injection when launching docker instance

### DIFF
--- a/issuer-front/.env
+++ b/issuer-front/.env
@@ -1,0 +1,2 @@
+REACT_APP_VERSION=$npm_package_version
+REACT_APP_NAME=$npm_package_name

--- a/issuer-front/Dockerfile
+++ b/issuer-front/Dockerfile
@@ -1,37 +1,33 @@
-FROM node:10-alpine as build
+FROM node:10-alpine as deps
 
 # Create app directory
 WORKDIR /usr/src/app
 
-# Install app dependencies
-# A wildcard is used to ensure both package.json AND package-lock.json are copied
-# where available (npm@5+)
-COPY package*.json ./
+COPY . .
 
 # Update and install some node dependencies
 RUN apk update && apk upgrade && \
     apk add --no-cache \
-        bash \
-        git \
-        openssh \
-        python \
-        make \
-        g++ \
-        && npm ci
+    bash \
+    git \
+    openssh \
+    python \
+    make \
+    g++ \
+    && npm ci
 
-COPY . .
+
+# This stage just builds the app to check it can be build without any errors
+FROM deps
+
+WORKDIR /usr/src/app
 RUN npm run build
 
-FROM node:10-alpine
+FROM deps
 
+WORKDIR /usr/src/app
 RUN npm install http-server-spa -g
-COPY --from=build /usr/src/app/build /var/www
-
-COPY .env /var/www
-
-# Add bash
-RUN apk add --no-cache bash
 
 EXPOSE 8088
 
-CMD ["http-server-spa", "/var/www", "index.html", "8088"]
+CMD ["bash", "./docker-run.sh"]

--- a/issuer-front/docker-run.sh
+++ b/issuer-front/docker-run.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/env bash
+
+echo "> Updating .env"
+echo $REACT_APP_API_URL >> .env
+cat .env
+
+echo "> Building the app"
+npm run build
+
+cd build
+
+http-server-spa . index.html 8088


### PR DESCRIPTION
# Description

As `create-react-app` does not support injecting runtime environment variables (due to the fact it compiles the code to static html) we are not able to inject runtime configs like backend uri.

# Proposed solution

There are several alternatives although the one used here is the one with least amount of codebase changes. Basically the app is `built` before running. It might make it slower to start but it will work just fine and we are sure we can inject something into `.env`.

# Breaking changes

When starting the container, `REACT_APP_API_URL` needs to be provided as environment variable.

**This will break current deployment workflow**

# How to test

```bash
docker build -t test .
docker run --rm -p 8088:8088 -e REACT_APP_API_URL=https://issuer.api.staging.didi.atixlabs.com/api/1.0/didi_issuer --name issuer-front test
```