### PR TITLE
Fix descripción de rutas para Swagger

### DIFF
--- a/routes/CertRoutes.js
+++ b/routes/CertRoutes.js
@@ -72,7 +72,7 @@ router.get(
 
 /**
  * @openapi
- *   /cert/:{id}:
+ *   /cert/{id}:
  *   get:
  *     summary: Retornar un certificado a partir de su id
  *     parameters:
@@ -212,7 +212,7 @@ router.post(
 
 /**
  * @openapi
- *   /cert/:{id}:
+ *   /cert/{id}:
  *   put:
  *     summary: Modifica un certificado con los datos recibidos
  *     parameters:
@@ -320,7 +320,7 @@ router.put(
 
 /**
  * @openapi
- *   /cert/:{id}:
+ *   /cert/{id}:
  *   delete:
  *     summary: Marca un certificado como borrado y lo revoca en caso de haber sido emitido
  *     parameters:
@@ -361,7 +361,7 @@ router.delete(
 
 /**
  * @openapi
- *   /cert/:{id}/emmit:
+ *   /cert/{id}/emmit:
  *   post:
  *     summary: Dado un id enviar certificado a didi-server para ser emitido
  *     parameters:

--- a/routes/ParticipantRoutes.js
+++ b/routes/ParticipantRoutes.js
@@ -71,7 +71,7 @@ router.get(
 
 /**
  * @openapi
- *   /participant/all/:{templateId}:
+ *   /participant/all/{templateId}:
  *   get:
  *     summary: Retorna los participantes con informacion vinculada a un modelo de certificado.
  *     parameters:
@@ -108,7 +108,7 @@ router.get(
 
 /**
  * @openapi
- *   /participant/new/:{requestCode}:
+ *   /participant/new/{requestCode}:
  *   get:
  *     summary: Retorna la informacion del participante con el codigo indicado, si la data fue modificada.
  *     parameters:
@@ -145,7 +145,7 @@ router.get(
 
 /**
  * @openapi
- *   /participant/:{did}:
+ *   /participant/{did}:
  *   get:
  *     summary: Retorna la info de participante asociada a un usuario en particular.
  *     parameters:
@@ -182,7 +182,7 @@ router.get(
 
 /**
  * @openapi
- *   /participant/new/:
+ *   /participant/new:
  *   post:
  *     summary: Inicializa la data de participante con unicamente el did y nombre.
  *     description: Carga por csv.
@@ -262,7 +262,7 @@ router.post(
 
 /**
  * @openapi
- *   /participant/:{id}/:
+ *   /participant/{id}:
  *   put:
  *     summary: Modifica la data de participante con los datos recibidos.
  *     parameters:
@@ -349,7 +349,7 @@ router.put(
 
 /**
  * @openapi
- *   /participant/:{id}:
+ *   /participant/{id}:
  *   delete:
  *     summary: Marca la data de participante como borrada.
  *     parameters:
@@ -388,7 +388,7 @@ router.delete(
 
 /**
  * @openapi
- *   /participant/:{requestCode}:
+ *   /participant/{requestCode}:
  *   post:
  *     summary: Carga de info de participante global a partir de un pedido de certificado realizado con "/template/request/:requestCode".
  *     parameters:
@@ -424,7 +424,7 @@ router.post(
 
 /**
  * @openapi
- *   /participant/:{templateId}/:{requestCode}:
+ *   /participant/{templateId}/{requestCode}:
  *   post:
  *     summary: Carga de info de participante para un template en particular a partir del QR generado en "/template/:id/qr/:requestCode".
  *     parameters:

--- a/routes/ProfileRoutes.js
+++ b/routes/ProfileRoutes.js
@@ -84,7 +84,7 @@ router.get(
 
 /**
  * @openapi
- *   /profile/:{id}:
+ *   /profile/{id}:
  *   put:
  *     summary: Editar un perfil
  *     description: Los tipos de usuarios a ingresar en el arreglo de types se encuentran en constants/Constats.js como USER_TYPES
@@ -131,7 +131,7 @@ router.put(
 
 /**
  * @openapi
- *   /profile/:{id}:
+ *   /profile/{id}:
  *   delete:
  *     summary: Borrar un perfil
  *     parameters:

--- a/routes/RegisterRoutes.js
+++ b/routes/RegisterRoutes.js
@@ -132,8 +132,8 @@ router.get(
 
 /**
  * @openapi
- *   /register/:{did}:
- *   post:
+ *   /register/{did}:
+ *   put:
  *     summary: Editar un registro
  *     description: Las definiciones de status se encuentran en elarchivo constants/Constants.js
  *     parameters:
@@ -180,7 +180,7 @@ router.put(
 
 /**
  * @openapi
- *   /register/:{did}/retry:
+ *   /register/{did}/retry:
  *   post:
  *     summary: Vuelve a intentar el delegate del Registro en DIDI
  *     parameters:
@@ -217,7 +217,7 @@ router.post(
 
 /**
  * @openapi
- *   /register/:{did}/refresh:
+ *   /register/{did}/refresh:
  *   post:
  *     summary: Refrescar registro en DIDI
  *     parameters:
@@ -254,7 +254,7 @@ router.post(
 
 /**
  * @openapi
- *   /register/:{did}:
+ *   /register/{did}:
  *   delete:
  *     summary: Revocar un registro
  *     parameters:

--- a/routes/TemplateRoutes.js
+++ b/routes/TemplateRoutes.js
@@ -39,7 +39,7 @@ router.get(
 
 /**
  * @openapi
- *   /template/:{id}:
+ *   /template/{id}:
  *   get:
  *     summary: Retorna un modelo de certificado a partir del id.
  *     parameters:
@@ -126,7 +126,7 @@ router.post(
 
 /**
  * @openapi
- *   /template/:{id}/:
+ *   /template/{id}:
  *   put:
  *     summary: Modifica un modelo de certificado con los datos recibidos.
  *     description: Las definiciones de type se encuentran en el archivo constants/Constants.js objeto "CERT_FIELD_TYPES"
@@ -282,7 +282,7 @@ router.put(
 
 /**
  * @openapi
- *   /template/:{id}:
+ *   /template/{id}:
  *   delete:
  *     summary: Marca un modelo de certificado como borrado.
  *     parameters:
@@ -334,7 +334,7 @@ router.delete(
 
 /**
  * @openapi
- *   /template/request/:{requestCode}:
+ *   /template/request/{requestCode}:
  *   post:
  *     summary: Emite un pedido de info de participante global a partir de un pedido de certificado.
  *     parameters:
@@ -407,7 +407,7 @@ router.post(
 
 /**
  * @openapi
- *   /template/:{id}/qr/:{requestCode}/:{registerId}:
+ *   /template/{id}/qr/{requestCode}/{registerId}:
  *   get:
  *     summary: Genera un QR para pedir info de participante para un template en particular.
  *     parameters:

--- a/routes/UserRoutes.js
+++ b/routes/UserRoutes.js
@@ -149,7 +149,7 @@ router.post(
 
 /**
  * @openapi
- *   /user/:id:
+ *   /user/{id}:
  *   delete:
  *     summary: Marca un usuario como borrado
  *     parameters:
@@ -218,7 +218,7 @@ router.get(
 
 /**
  * @openapi
- *   /user/:id:
+ *   /user/{id}:
  *   put:
  *     summary: Editar un usuario
  *     parameters:


### PR DESCRIPTION
- Se arregla la ruta descrita en algunos casos cuando lleva parámetro en la url que estaba mal codificada