### PR TITLE
Fix/credential revokation y

### DIFF
--- a/controllers/cert/updateById.js
+++ b/controllers/cert/updateById.js
@@ -3,10 +3,14 @@ const CertService = require('../../services/CertService');
 
 const updateById = async (req, res) => {
   const { id } = req.params;
-  const data = JSON.parse(req.body.data);
-  const { split } = req.body;
-  const { microCredentials } = req.body;
+  const { split, microCredentials } = req.body;
+  let data;
 
+  try {
+    data = JSON.parse(req.body.data);
+  } catch (e) {
+    return ResponseHandler.sendErr(res, new Error('El parametro data no es un JSON válido'));
+  }
   try {
     const cert = await CertService.edit(id, data, split, microCredentials);
     return ResponseHandler.sendRes(res, cert);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
 		"test": "jest",
 		"lint": "eslint --ext .js __tests__/ constants/ controllers/ models/ policies/ services/ routes/",
 		"lint:fix": "eslint --fix --ext .js __tests__/ constants/ controllers/ models/ policies/ services/ routes/",
-		"local": "node ./runLocal.js",
 		"start": "nodemon server.js"
 	},
 	"keywords": [

--- a/routes/CertRoutes.js
+++ b/routes/CertRoutes.js
@@ -356,7 +356,7 @@ router.delete(
   '/:id',
   validate(CERT_REVOCATION),
   checkValidationResult,
-  cert.updateById,
+  cert.removeById,
 );
 
 /**


### PR DESCRIPTION
- Se corrigió un error que no permitia revocar credenciales debido a que DELETE /api/1.0/didi_issuer/cert/:id no utilizaba el controlador apropiado.
- Se corrige **NetworkError when attempting to fetch resource.** en  **controllers/cert/updateById.js**  cuando **body.data** no es un JSON válido. 
- Eliminar script sin uso en package.json