### PR TITLE
feature/ME-53-update-endpoint-register-share-requests-did

### DIFF
--- a/controllers/register/readShareRequestsByDid.js
+++ b/controllers/register/readShareRequestsByDid.js
@@ -1,14 +1,21 @@
 const ResponseHandler = require('../../routes/utils/ResponseHandler');
 const RegisterService = require('../../services/RegisterService');
+const BlockchainService = require('../../services/BlockchainService');
 
 const readShareRequestsByDid = async (req, res) => {
   try {
     const { did } = req.params;
 
-    const shareRequestList = await RegisterService.getShareRequestsByDid(did, {
+    const { list, totalPages } = await RegisterService.getShareRequestsByDid(did, {
       iss: did,
     });
-    return ResponseHandler.sendRes(res, shareRequestList);
+    const decodedShareRequestList = await Promise.all(
+      list.map(async (shareReq) => {
+        const { payload } = await BlockchainService.decodeJWT(shareReq.jwt);
+        return { ...shareReq, payload };
+      }),
+    );
+    return ResponseHandler.sendRes(res, { list: decodedShareRequestList, totalPages });
   } catch (err) {
     // eslint-disable-next-line no-console
     console.log(err);

--- a/controllers/register/readShareRequestsByDid.js
+++ b/controllers/register/readShareRequestsByDid.js
@@ -5,8 +5,9 @@ const readShareRequestsByDid = async (req, res) => {
   try {
     const { did } = req.params;
 
-    const shareRequestList = await RegisterService.getShareRequestsByDid(did);
-
+    const shareRequestList = await RegisterService.getShareRequestsByDid(did, {
+      iss: did,
+    });
     return ResponseHandler.sendRes(res, shareRequestList);
   } catch (err) {
     // eslint-disable-next-line no-console

--- a/services/RegisterService.js
+++ b/services/RegisterService.js
@@ -146,12 +146,12 @@ module.exports.getShareRequestById = async function getShareRequestById(id, did)
   }
 };
 
-module.exports.getShareRequestsByDid = async function getShareRequestsByDid(did) {
+module.exports.getShareRequestsByDid = async function getShareRequestsByDid(did, params) {
   if (!did) throw missingDid;
   try {
     const authToken = await createIssuerAuthToken(did);
 
-    return await getShareRequestsFromDidi(authToken);
+    return await getShareRequestsFromDidi(authToken, params);
   } catch (err) {
     console.log(err);
     throw GET_SHARE_REQUEST;
@@ -183,7 +183,12 @@ module.exports.editRegister = async function editRegister(did, body, file) {
     if (!newDelegate) await sendEditDataToDidi(did, body, url);
 
     return register.edit({
-      status, name, description, imageId, blockHash, expireOn,
+      status,
+      name,
+      description,
+      imageId,
+      blockHash,
+      expireOn,
     });
   } catch (err) {
     console.log(err);
@@ -233,7 +238,10 @@ module.exports.refreshRegister = async function refreshRegister(did, token) {
 
     // Modifico el estado a Pendiente
     return register.edit({
-      status: CREATING, blockHash: '', messageError: '', expireOn: undefined,
+      status: CREATING,
+      blockHash: '',
+      messageError: '',
+      expireOn: undefined,
     });
   } catch (err) {
     console.log(err);

--- a/services/TokenService.js
+++ b/services/TokenService.js
@@ -4,11 +4,7 @@ const Constants = require('../constants/Constants');
 const Messages = require('../constants/Messages');
 const { getByDID } = require('../models/Register');
 const { createJWT } = require('./BlockchainService');
-const {
-  missingUserId,
-  missingToken,
-  missingDid,
-} = require('../constants/serviceErrors');
+const { missingUserId, missingToken, missingDid } = require('../constants/serviceErrors');
 const { DIDI_SERVER_DID } = require('../constants/Constants');
 
 const now = function now() {
@@ -18,10 +14,13 @@ const now = function now() {
 // genera token firmado
 module.exports.generateToken = function generateToken(userId) {
   if (!userId) throw missingUserId;
-  const token = jwt.sign({
-    userId,
-    exp: now() + 60 * 60 * 60 * 60,
-  }, Constants.ISSUER_SERVER_PRIVATE_KEY);
+  const token = jwt.sign(
+    {
+      userId,
+      exp: now() + 60 * 60 * 60 * 60,
+    },
+    Constants.ISSUER_SERVER_PRIVATE_KEY,
+  );
   return token;
 };
 
@@ -38,8 +37,8 @@ module.exports.getTokenData = function getTokenData(token) {
 };
 
 /*
-* Crea un token de autorizacion en didi-server, dado un emisor
-*/
+ * Crea un token de autorizacion en didi-server, dado un emisor
+ */
 module.exports.createIssuerAuthToken = async (did) => {
   if (!did) throw missingDid;
   try {
@@ -50,7 +49,7 @@ module.exports.createIssuerAuthToken = async (did) => {
     const exp = ((new Date().getTime() + 600000) / 1000) | 0;
     const payload = { auth: 'Token de autorizacion en didi server' };
 
-    return createJWT(issuer.did, issuer.private_key, payload, exp, `did:ethr:${DIDI_SERVER_DID}`);
+    return createJWT(issuer.did, issuer.private_key, payload, exp, DIDI_SERVER_DID);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.log(error);

--- a/services/utils/fetchs.js
+++ b/services/utils/fetchs.js
@@ -41,7 +41,9 @@ const sendRefreshToDidi = async function sendRefreshToDidi(did, token) {
 const sendEditDataToDidi = async function sendEditDataToDidi(did, body, imageUrl) {
   const { name, description } = body;
   return defaultFetch(`${Constants.DIDI_API}/issuer/${did}`, 'PATCH', {
-    name, description, imageUrl,
+    name,
+    description,
+    imageUrl,
   });
 };
 
@@ -57,13 +59,23 @@ const sendDidToDidi = async function sendDidToDidi(did, name, token, description
 };
 
 const sendShareRequestToDidi = async function sendShareRequestToDidi(did, jwt, authToken) {
-  return defaultFetch(`${Constants.DIDI_API}/issuer/${did}/shareRequest`, 'POST', {
-    jwt,
-  }, authToken);
+  return defaultFetch(
+    `${Constants.DIDI_API}/issuer/${did}/shareRequest`,
+    'POST',
+    {
+      jwt,
+    },
+    authToken,
+  );
 };
 
-const getShareRequestsFromDidi = async function getShareRequestsFromDidi(authToken) {
-  return defaultFetch(`${Constants.DIDI_API}/shareRequest/list`, 'GET', undefined, authToken);
+const getShareRequestsFromDidi = async function getShareRequestsFromDidi(authToken, params) {
+  return defaultFetch(
+    `${Constants.DIDI_API}/shareRequest/list?${new URLSearchParams(params).toString()}`,
+    'GET',
+    undefined,
+    authToken,
+  );
 };
 
 const getShareRequestFromId = async function getShareRequestFromId(id, authToken) {


### PR DESCRIPTION
Added params to use the get all shareRequest endpoint

**New Comment**
I had to change the DIDI_SERVER_DID var at .env file to make it work. And also removed the `did:eht: usage` at TokenService.js - So, we should check how this env var is defined in prod